### PR TITLE
fix cutotune compile bug with backward in custom autograd function

### DIFF
--- a/cute_kernels/utils/cutotune.py
+++ b/cute_kernels/utils/cutotune.py
@@ -139,7 +139,7 @@ class _CutoTune:
 
         return result
 
-    @torch.inference_mode()
+    @torch.no_grad()
     def _cutotune(self, *args, **kwargs) -> tuple[CutoTuneConfig, float]:
         best_config = None
         best_time = float("inf")
@@ -162,8 +162,9 @@ class _CutoTune:
                 best_config = config
                 best_time = elapsed_time
 
-        assert best_config is not None, "no best_config found, check that at least 1 cutotune config is valid"
+        torch.cuda.empty_cache()
 
+        assert best_config is not None, "no best_config found, check that at least 1 cutotune config is valid"
         return best_config, best_time
 
     def _get_lookup_key(self, *args, **kwargs) -> Any:

--- a/cute_kernels/utils/cutotune.py
+++ b/cute_kernels/utils/cutotune.py
@@ -104,12 +104,6 @@ class _CutoTune:
     def _check_all_or_no_args_are_cutotune_parameters(self, *args, **kwargs) -> bool:
         num_cutotune_overrideables = 0
 
-        def _count(x: Any) -> Any:
-            nonlocal num_cutotune_overrideables
-            if isinstance(x, CutoTuneParameter):
-                num_cutotune_overrideables += 1
-            return x
-
         for i in range(len(args)):
             variable_name = self.signature.args[i]
 

--- a/cute_kernels/utils/cutotune.py
+++ b/cute_kernels/utils/cutotune.py
@@ -110,6 +110,7 @@ class _CutoTune:
             if isinstance(args[i], CutoTuneParameter) and variable_name in self.cutotuneable_parameters:
                 num_cutotune_overrideables += 1
 
+        # accessing kwargs.items() breaks torch.compile in backwards of a custom autograd function
         for variable_name in kwargs:
             if (
                 isinstance(kwargs.get(variable_name), CutoTuneParameter)
@@ -136,6 +137,7 @@ class _CutoTune:
             if override_allowed or variable_name not in result:
                 result[variable_name] = args[i]
 
+        # accessing kwargs.items() breaks torch.compile in backwards of a custom autograd function
         for variable_name in kwargs:
             if override_allowed or variable_name not in result:
                 result[variable_name] = kwargs.get(variable_name)

--- a/cute_kernels/utils/cutotune.py
+++ b/cute_kernels/utils/cutotune.py
@@ -101,15 +101,7 @@ class _CutoTune:
 
         return output
 
-    def _check_no_args_are_cutotune_parameters(self, *args, **kwargs) -> None:
-        for i, value in enumerate(args):
-            assert not isinstance(
-                value, CutoTuneParameter
-            ), f"{self.signature.args[i]} should not be CutoTuneParameter"
-
-        for variable_name, value in kwargs.items():
-            assert not isinstance(value, CutoTuneParameter), f"{variable_name} should not be CutoTuneParameter"
-
+    @torch._dynamo.disable
     def _check_all_or_no_args_are_cutotune_parameters(self, *args, **kwargs) -> bool:
         num_cutotune_overrideables = 0
 


### PR DESCRIPTION
accessing kwargs.items() breaks torch.compile in backward