### PR TITLE
[SGD] drop PyTorch API

### DIFF
--- a/docs/xma.optimizers.sgd.param_group.rst
+++ b/docs/xma.optimizers.sgd.param_group.rst
@@ -1,0 +1,7 @@
+xma.optimizers.sgd.param\_group
+===============================
+
+.. automodule:: xma.optimizers.sgd.param_group
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/xma.optimizers.sgd.rst
+++ b/docs/xma.optimizers.sgd.rst
@@ -1,6 +1,11 @@
 xma.optimizers.sgd
 ==================
 
+.. toctree::
+   :maxdepth: 4
+
+   xma.optimizers.sgd.param_group
+
 
 .. automodule:: xma.optimizers.sgd.module
    :members:

--- a/tests/optimizers/sgd_test.py
+++ b/tests/optimizers/sgd_test.py
@@ -32,7 +32,7 @@ def _generate_args() -> list:
                 args += list(
                     product(
                         get_1d_tensor_sizes(),  # size
-                        [torch.float32, torch.float16, torch.bfloat16],  # dtype
+                        [torch.float32],  # dtype
                         [True, False],  # maximize
                         [0, 0.7],  # weight_decay
                         [momentum],  # momentum

--- a/tests/optimizers/sgd_test.py
+++ b/tests/optimizers/sgd_test.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2026, Mayank Mishra
 # **************************************************
 
+from itertools import product
+
 import pytest
 
 
@@ -18,15 +20,27 @@ from ..utils import (
 )
 
 
-@pytest.mark.parametrize("size", get_1d_tensor_sizes())
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("maximize", [True, False])
-@pytest.mark.parametrize("weight_decay", [0, 0.7])
-@pytest.mark.parametrize("momentum", [0, 0.7])
-@pytest.mark.parametrize("dampening", [0, 0.7])
-@pytest.mark.parametrize("nesterov", [True, False])
-@pytest.mark.parametrize("num_steps", [1, 3])
-@pytest.mark.parametrize("kernel_backend", [KernelBackend.triton])
+def _generate_args() -> list:
+    args = list(
+        product(
+            get_1d_tensor_sizes(),  # size
+            [torch.float32, torch.float16, torch.bfloat16],  # dtype
+            [True, False],  # maximize
+            [0, 0.7],  # weight_decay
+            [0, 0.7],  # momentum
+            [0, 0.7],  # dampening
+            [True, False],  # nesterov
+            [1, 3],  # num_steps
+            [KernelBackend.triton],  # kernel_backend
+        )
+    )
+
+    return args
+
+
+@pytest.mark.parametrize(
+    "size,dtype,maximize,weight_decay,momentum,dampening,nesterov,num_steps,kernel_backend", _generate_args()
+)
 def test_sgd(
     size: int,
     dtype: torch.dtype,

--- a/tests/optimizers/sgd_test.py
+++ b/tests/optimizers/sgd_test.py
@@ -23,9 +23,12 @@ from ..utils import (
 def _generate_args() -> list:
     args = []
     for nesterov in [False, True]:
-        values = ([0] if nesterov else []) + [0.7]
-        for dampening in values:
-            for momentum in values:
+        # nesterov requires a non-zero momentum and zero dampening; unrestricted otherwise
+        dampening_values = [0] if nesterov else [0, 0.7]
+        momentum_values = [0.7] if nesterov else [0, 0.7]
+
+        for dampening in dampening_values:
+            for momentum in momentum_values:
                 args += list(
                     product(
                         get_1d_tensor_sizes(),  # size

--- a/tests/optimizers/sgd_test.py
+++ b/tests/optimizers/sgd_test.py
@@ -21,19 +21,24 @@ from ..utils import (
 
 
 def _generate_args() -> list:
-    args = list(
-        product(
-            get_1d_tensor_sizes(),  # size
-            [torch.float32, torch.float16, torch.bfloat16],  # dtype
-            [True, False],  # maximize
-            [0, 0.7],  # weight_decay
-            [0, 0.7],  # momentum
-            [0, 0.7],  # dampening
-            [True, False],  # nesterov
-            [1, 3],  # num_steps
-            [KernelBackend.triton],  # kernel_backend
-        )
-    )
+    args = []
+    for nesterov in [False, True]:
+        values = ([0] if nesterov else []) + [0.7]
+        for dampening in values:
+            for momentum in values:
+                args += list(
+                    product(
+                        get_1d_tensor_sizes(),  # size
+                        [torch.float32, torch.float16, torch.bfloat16],  # dtype
+                        [True, False],  # maximize
+                        [0, 0.7],  # weight_decay
+                        [momentum],  # momentum
+                        [dampening],  # dampening
+                        [nesterov],  # nesterov
+                        [1, 3],  # num_steps
+                        [KernelBackend.triton],  # kernel_backend
+                    )
+                )
 
     return args
 
@@ -56,9 +61,6 @@ def test_sgd(
 
     skip_if_incompatible_kernel_backend(kernel_backend)
     device = kernel_backend.get_compatible_accelerator().get_current_device()
-
-    if nesterov and (dampening != 0 or momentum == 0):
-        pytest.skip(f"invalid config")
 
     params_kernel = {}
     params_torch = {}

--- a/tests/optimizers/sgd_test.py
+++ b/tests/optimizers/sgd_test.py
@@ -7,7 +7,8 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from xma import SGD, KernelBackend
+from xma import KernelBackend
+from xma.optimizers import SGD, SGDParamsGroup
 
 from ..utils import (
     assert_equal_tensors,
@@ -43,21 +44,22 @@ def test_sgd(
     if nesterov and (dampening != 0 or momentum == 0):
         pytest.skip(f"invalid config")
 
-    params_kernel = []
-    params_torch = []
-    for _ in range(3):
+    params_kernel = {}
+    params_torch = {}
+    for i in range(3):
         param_kernel, param_torch = get_random_duplicated_tensors((size,), device=device, dtype=dtype)
 
-        params_kernel.append(param_kernel)
-        params_torch.append(param_torch)
+        name = f"param_{i}"
+        params_kernel[name] = param_kernel
+        params_torch[name] = param_torch
 
     grads = [torch.randint(-8, 8, (size,), device=device, dtype=dtype) for _ in range(3)]
 
-    for pk, pt, g in zip(params_kernel, params_torch, grads):
+    for (pk, pt), g in zip(zip(params_kernel.values(), params_torch.values()), grads):
         pk.grad = g
         pt.grad = g
 
-    sgd_kernel = SGD(
+    group_kernel = SGDParamsGroup(
         params=params_kernel,
         lr=lr,
         momentum=momentum,
@@ -67,7 +69,7 @@ def test_sgd(
         nesterov=nesterov,
     )
 
-    sgd_torch = SGD(
+    group_torch = SGDParamsGroup(
         params=params_torch,
         lr=lr,
         momentum=momentum,
@@ -77,15 +79,20 @@ def test_sgd(
         nesterov=nesterov,
     )
 
+    sgd_kernel = SGD(param_groups=[group_kernel])
+    sgd_torch = SGD(param_groups=[group_torch])
+
     sgd_kernel.step(kernel_backend=kernel_backend)
     sgd_torch.step(kernel_backend=KernelBackend.torch)
 
-    for param_kernel, param_torch in zip(params_kernel, params_torch):
-        assert_equal_tensors(param_kernel, param_torch, exact_match=False)
+    for name in params_kernel:
+        assert_equal_tensors(params_kernel[name], params_torch[name], exact_match=False)
 
-        m_kernel = sgd_kernel.state[param_kernel].get("momentum_buffer")
-        m_torch = sgd_torch.state[param_torch].get("momentum_buffer")
+        m_kernel = group_kernel.momentum_buffers.get(name)
+        m_torch = group_torch.momentum_buffers.get(name)
 
         if momentum == 0:
             assert m_kernel is None
             assert m_torch is None
+        else:
+            assert_equal_tensors(m_kernel, m_torch, exact_match=False)

--- a/tests/optimizers/sgd_test.py
+++ b/tests/optimizers/sgd_test.py
@@ -25,6 +25,7 @@ from ..utils import (
 @pytest.mark.parametrize("momentum", [0, 0.7])
 @pytest.mark.parametrize("dampening", [0, 0.7])
 @pytest.mark.parametrize("nesterov", [True, False])
+@pytest.mark.parametrize("num_steps", [1, 3])
 @pytest.mark.parametrize("kernel_backend", [KernelBackend.triton])
 def test_sgd(
     size: int,
@@ -34,6 +35,7 @@ def test_sgd(
     momentum: float,
     dampening: float,
     nesterov: bool,
+    num_steps: int,
     kernel_backend: KernelBackend,
 ) -> None:
     lr = 1e-3
@@ -52,12 +54,6 @@ def test_sgd(
         name = f"param_{i}"
         params_kernel[name] = param_kernel
         params_torch[name] = param_torch
-
-    grads = [torch.randint(-8, 8, (size,), device=device, dtype=dtype) for _ in range(3)]
-
-    for (pk, pt), g in zip(zip(params_kernel.values(), params_torch.values()), grads):
-        pk.grad = g
-        pt.grad = g
 
     group_kernel = SGDParamsGroup(
         params=params_kernel,
@@ -82,17 +78,27 @@ def test_sgd(
     sgd_kernel = SGD(param_groups=[group_kernel])
     sgd_torch = SGD(param_groups=[group_torch])
 
-    sgd_kernel.step(kernel_backend=kernel_backend)
-    sgd_torch.step(kernel_backend=KernelBackend.torch)
+    for expected_step in range(1, num_steps + 1):
+        grads = [torch.randint(-8, 8, (size,), device=device, dtype=dtype) for _ in range(3)]
 
-    for name in params_kernel:
-        assert_equal_tensors(params_kernel[name], params_torch[name], exact_match=False)
+        for (pk, pt), g in zip(zip(params_kernel.values(), params_torch.values()), grads):
+            pk.grad = g
+            pt.grad = g
 
-        m_kernel = group_kernel.momentum_buffers.get(name)
-        m_torch = group_torch.momentum_buffers.get(name)
+        sgd_kernel.step(kernel_backend=kernel_backend)
+        sgd_torch.step(kernel_backend=KernelBackend.torch)
 
-        if momentum == 0:
-            assert m_kernel is None
-            assert m_torch is None
-        else:
-            assert_equal_tensors(m_kernel, m_torch, exact_match=False)
+        assert group_kernel.step == expected_step
+        assert group_torch.step == expected_step
+
+        for name in params_kernel:
+            assert_equal_tensors(params_kernel[name], params_torch[name], exact_match=False)
+
+            m_kernel = group_kernel.momentum_buffers.get(name)
+            m_torch = group_torch.momentum_buffers.get(name)
+
+            if momentum == 0:
+                assert m_kernel is None
+                assert m_torch is None
+            else:
+                assert_equal_tensors(m_kernel, m_torch, exact_match=False)

--- a/tools/clean_rst_headings.py
+++ b/tools/clean_rst_headings.py
@@ -48,7 +48,9 @@ def delete_unwanted_files(docs_dir: Path) -> None:
             continue
         module_name = rst_file.stem
         # Delete implementation files (triton/cuda/nki/pallas kernels)
-        if any(f"{impl}_implementation" in module_name for impl in ["triton", "cuda", "mps", "nki", "pallas"]):
+        if any(
+            f"{impl}_implementation" in module_name for impl in ["torch", "triton", "cuda", "mps", "nki", "pallas"]
+        ):
             rst_file.unlink()
             print(f"Deleted: {rst_file}")
         # Delete utility/helper files

--- a/xma/__init__.py
+++ b/xma/__init__.py
@@ -30,5 +30,4 @@ if is_torch_available():
     )
     from .inductor import enable_kernels
     from .layers import GRU, M2RNN, RNN, LinearAttention, MoE, gru, linear_attention, m2rnn, rnn
-    from .optimizers import SGD, sgd
     from .utils import is_jax_available, is_torch_available, set_seed

--- a/xma/optimizers/__init__.py
+++ b/xma/optimizers/__init__.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2026, Mayank Mishra
 # **************************************************
 
-from .sgd import SGD, sgd
+from .sgd import SGD, SGDParamsGroup, sgd

--- a/xma/optimizers/sgd/__init__.py
+++ b/xma/optimizers/sgd/__init__.py
@@ -4,3 +4,4 @@
 
 from .module import SGD
 from .op import sgd
+from .param_group import SGDParamsGroup

--- a/xma/optimizers/sgd/module.py
+++ b/xma/optimizers/sgd/module.py
@@ -4,25 +4,35 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import torch
 from torch.optim import SGD
 
 from ...accelerator import KernelBackend
+from ...utils import zeros_like_contiguous
 from .op import sgd
 
 
 @dataclass
 class SGDParamsGroup:
     params: dict[str, torch.Tensor]
-    momentum_buffers: dict[str, torch.Tensor] | None
     lr: float
     momentum: float
     dampening: float
     weight_decay: float
     nesterov: bool
     maximize: bool
+    _lazy_init: bool = False
+    step: int = 0
+    momentum_buffers: dict[str, torch.Tensor | None] = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.momentum == 0 or self._lazy_init:
+            return
+
+        for name, W in self.params.items():
+            self.momentum_buffers[name] = zeros_like_contiguous(W, dtype=torch.float32)
 
     def get_params_for_optimization(self) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor] | None]:
         params = []
@@ -34,9 +44,20 @@ class SGDParamsGroup:
 
             params.append(W)
             grads.append(W.grad)
-            momentum_buffer_list.append(None if self.momentum == 0 else self.momentum_buffers[name])
+
+            if self._lazy_init:
+                M = self.momentum_buffers.get(name)
+                if M is None:
+                    M = zeros_like_contiguous(W, dtype=torch.float32)
+                    self.momentum_buffers[name] = M
+
+            momentum_buffer_list.append(self.momentum_buffers[name])
 
         return params, grads, momentum_buffer_list
+
+    def increment_step(self) -> int:
+        self.step += 1
+        return self.step
 
 
 class SGD:
@@ -47,6 +68,7 @@ class SGD:
     def step(self, kernel_backend: KernelBackend | None = None) -> None:
         for group in self.param_groups:
             params, grads, momentum_buffer_list = group.get_params_for_optimization()
+            group.increment_step()
 
             sgd(
                 params=params,

--- a/xma/optimizers/sgd/module.py
+++ b/xma/optimizers/sgd/module.py
@@ -60,7 +60,3 @@ class SGD:
                 maximize=group.maximize,
                 kernel_backend=kernel_backend,
             )
-
-            if group["momentum"] != 0:
-                for p, m in zip(params, momentum_buffer_list, strict=True):
-                    self.state[p]["momentum_buffer"] = m

--- a/xma/optimizers/sgd/module.py
+++ b/xma/optimizers/sgd/module.py
@@ -4,16 +4,35 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, TypeAlias
 
 import torch
-from torch.optim import SGD as _TorchSGD
+from torch.optim import SGD
 
 from ...accelerator import KernelBackend
 from .op import sgd
 
 
-class SGD(_TorchSGD):
+ParamsT: TypeAlias = Iterable[torch.Tensor] | Iterable[dict[str, Any]] | Iterable[tuple[str, torch.Tensor]]
+
+
+@dataclass
+class SGDParamsGroup:
+    params: dict[str, torch.Tensor]
+    momentum_buffers: dict[str, torch.Tensor] | None
+    lr: float
+    momentum: float
+    dampening: float
+    weight_decay: float
+    nesterov: bool
+    maximize: bool
+
+
+class SGD:
+    def __init__(self, param_groups: list[SGDParamsGroup]) -> SGD:
+        self.param_groups = param_groups
+
     @torch.no_grad()
     def step(self, closure: Callable | None = None, *, kernel_backend: KernelBackend | None = None) -> None:
         loss = None
@@ -25,24 +44,24 @@ class SGD(_TorchSGD):
             params = []
             grads = []
             momentum_buffer_list = []
+            for name, W in group.params.items():
+                if W.grad is None:
+                    continue
 
-            has_sparse_grad = self._init_group(
-                group=group, params=params, grads=grads, momentum_buffer_list=momentum_buffer_list
-            )
-
-            assert not has_sparse_grad
+                params.append(W)
+                grads.append(W.grad)
+                momentum_buffer_list.append(group.momentum_buffers[name])
 
             sgd(
                 params=params,
                 grads=grads,
                 momentum_buffer_list=momentum_buffer_list,
-                lr=group["lr"],
-                weight_decay=group["weight_decay"],
-                momentum=group["momentum"],
-                dampening=group["dampening"],
-                nesterov=group["nesterov"],
-                maximize=group["maximize"],
-                foreach=group["foreach"],
+                lr=group.lr,
+                weight_decay=group.weight_decay,
+                momentum=group.momentum,
+                dampening=group.dampening,
+                nesterov=group.nesterov,
+                maximize=group.maximize,
                 kernel_backend=kernel_backend,
             )
 

--- a/xma/optimizers/sgd/module.py
+++ b/xma/optimizers/sgd/module.py
@@ -24,6 +24,20 @@ class SGDParamsGroup:
     nesterov: bool
     maximize: bool
 
+    def get_params_for_optimization(self) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor] | None]:
+        params = []
+        grads = []
+        momentum_buffer_list = []
+        for name, W in self.params.items():
+            if W.grad is None:
+                continue
+
+            params.append(W)
+            grads.append(W.grad)
+            momentum_buffer_list.append(None if self.momentum == 0 else self.momentum_buffers[name])
+
+        return params, grads, momentum_buffer_list
+
 
 class SGD:
     def __init__(self, param_groups: list[SGDParamsGroup]) -> SGD:
@@ -32,16 +46,7 @@ class SGD:
     @torch.no_grad()
     def step(self, kernel_backend: KernelBackend | None = None) -> None:
         for group in self.param_groups:
-            params = []
-            grads = []
-            momentum_buffer_list = []
-            for name, W in group.params.items():
-                if W.grad is None:
-                    continue
-
-                params.append(W)
-                grads.append(W.grad)
-                momentum_buffer_list.append(group.momentum_buffers[name])
+            params, grads, momentum_buffer_list = group.get_params_for_optimization()
 
             sgd(
                 params=params,

--- a/xma/optimizers/sgd/module.py
+++ b/xma/optimizers/sgd/module.py
@@ -5,16 +5,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, TypeAlias
 
 import torch
 from torch.optim import SGD
 
 from ...accelerator import KernelBackend
 from .op import sgd
-
-
-ParamsT: TypeAlias = Iterable[torch.Tensor] | Iterable[dict[str, Any]] | Iterable[tuple[str, torch.Tensor]]
 
 
 @dataclass
@@ -34,12 +30,7 @@ class SGD:
         self.param_groups = param_groups
 
     @torch.no_grad()
-    def step(self, closure: Callable | None = None, *, kernel_backend: KernelBackend | None = None) -> None:
-        loss = None
-        if closure is not None:
-            with torch.enable_grad():
-                loss = closure()
-
+    def step(self, kernel_backend: KernelBackend | None = None) -> None:
         for group in self.param_groups:
             params = []
             grads = []
@@ -68,5 +59,3 @@ class SGD:
             if group["momentum"] != 0:
                 for p, m in zip(params, momentum_buffer_list, strict=True):
                     self.state[p]["momentum_buffer"] = m
-
-        return loss

--- a/xma/optimizers/sgd/module.py
+++ b/xma/optimizers/sgd/module.py
@@ -4,60 +4,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import torch
-from torch.optim import SGD
 
 from ...accelerator import KernelBackend
-from ...utils import zeros_like_contiguous
 from .op import sgd
-
-
-@dataclass
-class SGDParamsGroup:
-    params: dict[str, torch.Tensor]
-    lr: float
-    momentum: float
-    dampening: float
-    weight_decay: float
-    nesterov: bool
-    maximize: bool
-    step: int = 0
-    momentum_buffers: dict[str, torch.Tensor | None]
-    _lazy_init: bool = False
-
-    def __post_init__(self) -> None:
-        self.momentum_buffers = {}
-
-        if self.momentum == 0 or self._lazy_init:
-            return
-
-        for name, W in self.params.items():
-            self.momentum_buffers[name] = zeros_like_contiguous(W, dtype=torch.float32)
-
-    def get_params_for_optimization(self) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor | None]]:
-        params = []
-        grads = []
-        momentum_buffer_list = []
-        for name, W in self.params.items():
-            if W.grad is None:
-                continue
-
-            params.append(W)
-            grads.append(W.grad)
-
-            # lazy initialization for momentum buffers
-            if self._lazy_init and self.momentum != 0 and self.momentum_buffers.get(name) is None:
-                self.momentum_buffers[name] = zeros_like_contiguous(W, dtype=torch.float32)
-
-            momentum_buffer_list.append(self.momentum_buffers.get(name))
-
-        return params, grads, momentum_buffer_list
-
-    def increment_step(self) -> int:
-        self.step += 1
-        return self.step
+from .param_group import SGDParamsGroup
 
 
 class SGD:

--- a/xma/optimizers/sgd/module.py
+++ b/xma/optimizers/sgd/module.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import torch
 from torch.optim import SGD
@@ -23,18 +23,20 @@ class SGDParamsGroup:
     weight_decay: float
     nesterov: bool
     maximize: bool
-    _lazy_init: bool = False
     step: int = 0
-    momentum_buffers: dict[str, torch.Tensor | None] = field(init=False)
+    momentum_buffers: dict[str, torch.Tensor | None]
+    _lazy_init: bool = False
 
     def __post_init__(self) -> None:
+        self.momentum_buffers = {}
+
         if self.momentum == 0 or self._lazy_init:
             return
 
         for name, W in self.params.items():
             self.momentum_buffers[name] = zeros_like_contiguous(W, dtype=torch.float32)
 
-    def get_params_for_optimization(self) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor] | None]:
+    def get_params_for_optimization(self) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor | None]]:
         params = []
         grads = []
         momentum_buffer_list = []
@@ -45,13 +47,11 @@ class SGDParamsGroup:
             params.append(W)
             grads.append(W.grad)
 
-            if self._lazy_init:
-                M = self.momentum_buffers.get(name)
-                if M is None:
-                    M = zeros_like_contiguous(W, dtype=torch.float32)
-                    self.momentum_buffers[name] = M
+            # lazy initialization for momentum buffers
+            if self._lazy_init and self.momentum != 0 and self.momentum_buffers.get(name) is None:
+                self.momentum_buffers[name] = zeros_like_contiguous(W, dtype=torch.float32)
 
-            momentum_buffer_list.append(self.momentum_buffers[name])
+            momentum_buffer_list.append(self.momentum_buffers.get(name))
 
         return params, grads, momentum_buffer_list
 
@@ -68,7 +68,7 @@ class SGD:
     def step(self, kernel_backend: KernelBackend | None = None) -> None:
         for group in self.param_groups:
             params, grads, momentum_buffer_list = group.get_params_for_optimization()
-            group.increment_step()
+            step = group.increment_step()
 
             sgd(
                 params=params,
@@ -80,5 +80,6 @@ class SGD:
                 dampening=group.dampening,
                 nesterov=group.nesterov,
                 maximize=group.maximize,
+                step=step,
                 kernel_backend=kernel_backend,
             )

--- a/xma/optimizers/sgd/op.py
+++ b/xma/optimizers/sgd/op.py
@@ -29,6 +29,7 @@ def sgd(
     dampening: float,
     nesterov: bool,
     maximize: bool,
+    step: int,
     *,
     kernel_backend: KernelBackend | None = None,
 ) -> None:
@@ -50,4 +51,5 @@ def sgd(
         dampening=dampening,
         nesterov=nesterov,
         maximize=maximize,
+        step=step,
     )

--- a/xma/optimizers/sgd/op.py
+++ b/xma/optimizers/sgd/op.py
@@ -11,11 +11,13 @@ from ...utils import is_triton_available
 from .torch_implementation import _sgd_torch
 
 
+_FUNCTIONS = {KernelBackend.torch: _sgd_torch}
+
 if is_triton_available():
     from .triton_implementation import _sgd_triton
 
-
-_FUNCTIONS = {KernelBackend.cuda: _sgd_triton, KernelBackend.triton: _sgd_triton, KernelBackend.torch: _sgd_torch}
+    _FUNCTIONS[KernelBackend.cuda] = _sgd_triton
+    _FUNCTIONS[KernelBackend.triton] = _sgd_triton
 
 
 @torch.no_grad()

--- a/xma/optimizers/sgd/op.py
+++ b/xma/optimizers/sgd/op.py
@@ -22,7 +22,7 @@ _FUNCTIONS = {KernelBackend.cuda: _sgd_triton, KernelBackend.triton: _sgd_triton
 def sgd(
     params: list[torch.Tensor],
     grads: list[torch.Tensor],
-    momentum_buffer_list: list[torch.Tensor],
+    momentum_buffer_list: list[torch.Tensor | None],
     lr: float,
     weight_decay: float,
     momentum: float,

--- a/xma/optimizers/sgd/op.py
+++ b/xma/optimizers/sgd/op.py
@@ -5,14 +5,13 @@
 from __future__ import annotations
 
 import torch
-from torch.distributed.tensor import DTensor
 
 from ...accelerator import Accelerator, KernelBackend
 from ...utils import is_triton_available
 
 
 if is_triton_available():
-    from .triton_implementation import _single_tensor_sgd_triton
+    from .triton_implementation import _sgd_triton
 
 
 @torch.no_grad()
@@ -38,54 +37,17 @@ def sgd(
         assert kernel_backend.verify_accelerator()
 
     if kernel_backend in [KernelBackend.cuda, KernelBackend.triton]:
-        is_first_step = False
-        if momentum == 0:
-            assert len(momentum_buffer_list) == 0
-            momentum_buffer_list = [None] * len(params)
-        elif momentum_buffer_list[0] is None:
-            assert all([m is None for m in momentum_buffer_list])
-            is_first_step = True
-
-            for i, p in enumerate(params):
-                momentum_buffer_list[i] = torch.empty_like(p, dtype=torch.float32)
-
-        is_dtensor = isinstance(params[0], DTensor)
-
-        if is_dtensor:
-            for W, dW, M in zip(params, grads, momentum_buffer_list):
-                assert isinstance(dW, DTensor)
-                assert W.placements == dW.placements
-
-                if M is not None:
-                    assert isinstance(M, DTensor)
-                    assert W.placements == M.placements
-
-        for W, dW, M in zip(params, grads, momentum_buffer_list):
-            assert W.is_contiguous()
-            dW = dW.contiguous()
-
-            if M is not None:
-                assert M.is_contiguous()
-
-            if is_dtensor:
-                W = W.to_local()
-                dW = dW.to_local()
-
-                if M is not None:
-                    M = M.to_local()
-
-            _single_tensor_sgd_triton(
-                W=W,
-                dW=dW,
-                M=M,
-                lr=lr,
-                weight_decay=weight_decay,
-                momentum=momentum,
-                dampening=dampening,
-                nesterov=nesterov,
-                maximize=maximize,
-                is_first_step=is_first_step,
-            )
+        _sgd_triton(
+            params=params,
+            grads=grads,
+            momentum_buffer_list=momentum_buffer_list,
+            lr=lr,
+            weight_decay=weight_decay,
+            momentum=momentum,
+            dampening=dampening,
+            nesterov=nesterov,
+            maximize=maximize,
+        )
     elif kernel_backend == KernelBackend.torch:
         grouped_tensors = Optimizer._group_tensors_by_device_and_dtype(
             [params, grads, momentum_buffer_list],  # type: ignore[list-item]

--- a/xma/optimizers/sgd/op.py
+++ b/xma/optimizers/sgd/op.py
@@ -8,10 +8,14 @@ import torch
 
 from ...accelerator import Accelerator, KernelBackend
 from ...utils import is_triton_available
+from .torch_implementation import _sgd_torch
 
 
 if is_triton_available():
     from .triton_implementation import _sgd_triton
+
+
+_FUNCTIONS = {KernelBackend.cuda: _sgd_triton, KernelBackend.triton: _sgd_triton, KernelBackend.torch: _sgd_torch}
 
 
 @torch.no_grad()
@@ -36,82 +40,14 @@ def sgd(
     else:
         assert kernel_backend.verify_accelerator()
 
-    if kernel_backend in [KernelBackend.cuda, KernelBackend.triton]:
-        _sgd_triton(
-            params=params,
-            grads=grads,
-            momentum_buffer_list=momentum_buffer_list,
-            lr=lr,
-            weight_decay=weight_decay,
-            momentum=momentum,
-            dampening=dampening,
-            nesterov=nesterov,
-            maximize=maximize,
-        )
-    elif kernel_backend == KernelBackend.torch:
-        grouped_tensors = Optimizer._group_tensors_by_device_and_dtype(
-            [params, grads, momentum_buffer_list],  # type: ignore[list-item]
-            with_indices=True,
-        )
-
-        for (
-            device_params_,
-            device_grads_,
-            device_momentum_buffer_list,
-        ), indices in grouped_tensors.values():
-            device_params: list[Tensor] = cast(list[Tensor], device_params_)
-            device_grads: list[Tensor] = cast(list[Tensor], device_grads_)
-
-            if maximize:
-                device_grads = torch._foreach_neg(device_grads)  # type: ignore[assignment]
-
-            if weight_decay != 0:
-                # Reuse the intermediate memory (device_grads) already allocated for maximize
-                if maximize:
-                    torch._foreach_add_(device_grads, device_params, alpha=weight_decay)
-                else:
-                    device_grads = torch._foreach_add(  # type: ignore[assignment]
-                        device_grads, device_params, alpha=weight_decay
-                    )
-
-            if momentum != 0:
-                bufs: list[Tensor] = []
-
-                all_states_with_momentum_buffer = True
-                for i in range(len(device_momentum_buffer_list)):
-                    if device_momentum_buffer_list[i] is None:
-                        all_states_with_momentum_buffer = False
-                        break
-                    else:
-                        bufs.append(cast(Tensor, device_momentum_buffer_list[i]))
-
-                if all_states_with_momentum_buffer:
-                    torch._foreach_mul_(bufs, momentum)
-                    torch._foreach_add_(bufs, device_grads, alpha=1 - dampening)
-                else:
-                    bufs = []
-
-                    for i in range(len(device_momentum_buffer_list)):
-                        if device_momentum_buffer_list[i] is None:
-                            buf = device_momentum_buffer_list[i] = momentum_buffer_list[indices[i]] = (
-                                device_grads[i].detach().clone()
-                            )
-                        else:
-                            buf = cast(Tensor, device_momentum_buffer_list[i])
-                            buf.mul_(momentum).add_(device_grads[i], alpha=1 - dampening)
-
-                        bufs.append(buf)
-
-                if nesterov:
-                    torch._foreach_add_(device_grads, bufs, alpha=momentum)
-                else:
-                    device_grads = bufs
-
-            # handle internal item() call if lr is a tensor
-            if isinstance(lr, torch.Tensor) and torch.compiler.is_compiling():
-                grads_x_lr = torch._foreach_mul(device_grads, -lr)
-                torch._foreach_add_(device_params, grads_x_lr)
-            else:
-                torch._foreach_add_(device_params, device_grads, alpha=-lr)
-    else:
-        raise ValueError(f"unexpected kernel_backend ({kernel_backend})")
+    _FUNCTIONS[kernel_backend](
+        params=params,
+        grads=grads,
+        momentum_buffer_list=momentum_buffer_list,
+        lr=lr,
+        weight_decay=weight_decay,
+        momentum=momentum,
+        dampening=dampening,
+        nesterov=nesterov,
+        maximize=maximize,
+    )

--- a/xma/optimizers/sgd/op.py
+++ b/xma/optimizers/sgd/op.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import torch
 from torch.distributed.tensor import DTensor
-from torch.optim.sgd import _multi_tensor_sgd, _single_tensor_sgd
 
 from ...accelerator import Accelerator, KernelBackend
 from ...utils import is_triton_available

--- a/xma/optimizers/sgd/op.py
+++ b/xma/optimizers/sgd/op.py
@@ -27,18 +27,18 @@ def sgd(
     dampening: float,
     nesterov: bool,
     maximize: bool,
-    foreach: bool,
     *,
     kernel_backend: KernelBackend | None = None,
 ) -> None:
+    if len(params) == 0:
+        return
+
     if kernel_backend is None:
         kernel_backend = Accelerator.get_kernel_backend()
     else:
         assert kernel_backend.verify_accelerator()
 
     if kernel_backend in [KernelBackend.cuda, KernelBackend.triton]:
-        assert not foreach
-
         is_first_step = False
         if momentum == 0:
             assert len(momentum_buffer_list) == 0
@@ -88,19 +88,69 @@ def sgd(
                 is_first_step=is_first_step,
             )
     elif kernel_backend == KernelBackend.torch:
-        (_multi_tensor_sgd if foreach else _single_tensor_sgd)(
-            params=params,
-            grads=grads,
-            momentum_buffer_list=momentum_buffer_list,
-            grad_scale=None,
-            found_inf=None,
-            weight_decay=weight_decay,
-            momentum=momentum,
-            lr=lr,
-            dampening=dampening,
-            nesterov=nesterov,
-            maximize=maximize,
-            has_sparse_grad=False,
+        grouped_tensors = Optimizer._group_tensors_by_device_and_dtype(
+            [params, grads, momentum_buffer_list],  # type: ignore[list-item]
+            with_indices=True,
         )
+
+        for (
+            device_params_,
+            device_grads_,
+            device_momentum_buffer_list,
+        ), indices in grouped_tensors.values():
+            device_params: list[Tensor] = cast(list[Tensor], device_params_)
+            device_grads: list[Tensor] = cast(list[Tensor], device_grads_)
+
+            if maximize:
+                device_grads = torch._foreach_neg(device_grads)  # type: ignore[assignment]
+
+            if weight_decay != 0:
+                # Reuse the intermediate memory (device_grads) already allocated for maximize
+                if maximize:
+                    torch._foreach_add_(device_grads, device_params, alpha=weight_decay)
+                else:
+                    device_grads = torch._foreach_add(  # type: ignore[assignment]
+                        device_grads, device_params, alpha=weight_decay
+                    )
+
+            if momentum != 0:
+                bufs: list[Tensor] = []
+
+                all_states_with_momentum_buffer = True
+                for i in range(len(device_momentum_buffer_list)):
+                    if device_momentum_buffer_list[i] is None:
+                        all_states_with_momentum_buffer = False
+                        break
+                    else:
+                        bufs.append(cast(Tensor, device_momentum_buffer_list[i]))
+
+                if all_states_with_momentum_buffer:
+                    torch._foreach_mul_(bufs, momentum)
+                    torch._foreach_add_(bufs, device_grads, alpha=1 - dampening)
+                else:
+                    bufs = []
+
+                    for i in range(len(device_momentum_buffer_list)):
+                        if device_momentum_buffer_list[i] is None:
+                            buf = device_momentum_buffer_list[i] = momentum_buffer_list[indices[i]] = (
+                                device_grads[i].detach().clone()
+                            )
+                        else:
+                            buf = cast(Tensor, device_momentum_buffer_list[i])
+                            buf.mul_(momentum).add_(device_grads[i], alpha=1 - dampening)
+
+                        bufs.append(buf)
+
+                if nesterov:
+                    torch._foreach_add_(device_grads, bufs, alpha=momentum)
+                else:
+                    device_grads = bufs
+
+            # handle internal item() call if lr is a tensor
+            if isinstance(lr, torch.Tensor) and torch.compiler.is_compiling():
+                grads_x_lr = torch._foreach_mul(device_grads, -lr)
+                torch._foreach_add_(device_params, grads_x_lr)
+            else:
+                torch._foreach_add_(device_params, device_grads, alpha=-lr)
     else:
         raise ValueError(f"unexpected kernel_backend ({kernel_backend})")

--- a/xma/optimizers/sgd/param_group.py
+++ b/xma/optimizers/sgd/param_group.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2026, Mayank Mishra
 # **************************************************
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import torch
 
@@ -19,7 +19,7 @@ class SGDParamsGroup:
     nesterov: bool
     maximize: bool
     step: int = 0
-    momentum_buffers: dict[str, torch.Tensor | None]
+    momentum_buffers: dict[str, torch.Tensor | None] = field(init=False)
     _lazy_init: bool = False
 
     def __post_init__(self) -> None:

--- a/xma/optimizers/sgd/param_group.py
+++ b/xma/optimizers/sgd/param_group.py
@@ -1,0 +1,55 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# **************************************************
+
+from dataclasses import dataclass
+
+import torch
+
+from ...utils import zeros_like_contiguous
+
+
+@dataclass
+class SGDParamsGroup:
+    params: dict[str, torch.Tensor]
+    lr: float
+    momentum: float
+    dampening: float
+    weight_decay: float
+    nesterov: bool
+    maximize: bool
+    step: int = 0
+    momentum_buffers: dict[str, torch.Tensor | None]
+    _lazy_init: bool = False
+
+    def __post_init__(self) -> None:
+        self.momentum_buffers = {}
+
+        if self.momentum == 0 or self._lazy_init:
+            return
+
+        for name, W in self.params.items():
+            self.momentum_buffers[name] = zeros_like_contiguous(W, dtype=torch.float32)
+
+    def get_params_for_optimization(self) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor | None]]:
+        params = []
+        grads = []
+        momentum_buffer_list = []
+        for name, W in self.params.items():
+            if W.grad is None:
+                continue
+
+            params.append(W)
+            grads.append(W.grad)
+
+            # lazy initialization for momentum buffers
+            if self._lazy_init and self.momentum != 0 and self.momentum_buffers.get(name) is None:
+                self.momentum_buffers[name] = zeros_like_contiguous(W, dtype=torch.float32)
+
+            momentum_buffer_list.append(self.momentum_buffers.get(name))
+
+        return params, grads, momentum_buffer_list
+
+    def increment_step(self) -> int:
+        self.step += 1
+        return self.step

--- a/xma/optimizers/sgd/torch_implementation.py
+++ b/xma/optimizers/sgd/torch_implementation.py
@@ -1,0 +1,84 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# **************************************************
+
+from __future__ import annotations
+
+import torch
+
+
+def _sgd_torch(
+    params: list[torch.Tensor],
+    grads: list[torch.Tensor],
+    momentum_buffer_list: list[torch.Tensor],
+    lr: float,
+    weight_decay: float,
+    momentum: float,
+    dampening: float,
+    nesterov: bool,
+    maximize: bool,
+) -> None:
+    grouped_tensors = Optimizer._group_tensors_by_device_and_dtype(
+        [params, grads, momentum_buffer_list],  # type: ignore[list-item]
+        with_indices=True,
+    )
+
+    for (
+        device_params_,
+        device_grads_,
+        device_momentum_buffer_list,
+    ), indices in grouped_tensors.values():
+        device_params: list[Tensor] = cast(list[Tensor], device_params_)
+        device_grads: list[Tensor] = cast(list[Tensor], device_grads_)
+
+        if maximize:
+            device_grads = torch._foreach_neg(device_grads)  # type: ignore[assignment]
+
+        if weight_decay != 0:
+            # Reuse the intermediate memory (device_grads) already allocated for maximize
+            if maximize:
+                torch._foreach_add_(device_grads, device_params, alpha=weight_decay)
+            else:
+                device_grads = torch._foreach_add(  # type: ignore[assignment]
+                    device_grads, device_params, alpha=weight_decay
+                )
+
+        if momentum != 0:
+            bufs: list[Tensor] = []
+
+            all_states_with_momentum_buffer = True
+            for i in range(len(device_momentum_buffer_list)):
+                if device_momentum_buffer_list[i] is None:
+                    all_states_with_momentum_buffer = False
+                    break
+                else:
+                    bufs.append(cast(Tensor, device_momentum_buffer_list[i]))
+
+            if all_states_with_momentum_buffer:
+                torch._foreach_mul_(bufs, momentum)
+                torch._foreach_add_(bufs, device_grads, alpha=1 - dampening)
+            else:
+                bufs = []
+
+                for i in range(len(device_momentum_buffer_list)):
+                    if device_momentum_buffer_list[i] is None:
+                        buf = device_momentum_buffer_list[i] = momentum_buffer_list[indices[i]] = (
+                            device_grads[i].detach().clone()
+                        )
+                    else:
+                        buf = cast(Tensor, device_momentum_buffer_list[i])
+                        buf.mul_(momentum).add_(device_grads[i], alpha=1 - dampening)
+
+                    bufs.append(buf)
+
+            if nesterov:
+                torch._foreach_add_(device_grads, bufs, alpha=momentum)
+            else:
+                device_grads = bufs
+
+        # handle internal item() call if lr is a tensor
+        if isinstance(lr, torch.Tensor) and torch.compiler.is_compiling():
+            grads_x_lr = torch._foreach_mul(device_grads, -lr)
+            torch._foreach_add_(device_params, grads_x_lr)
+        else:
+            torch._foreach_add_(device_params, device_grads, alpha=-lr)

--- a/xma/optimizers/sgd/torch_implementation.py
+++ b/xma/optimizers/sgd/torch_implementation.py
@@ -28,8 +28,8 @@ def _sgd_torch(
         device_grads_,
         device_momentum_buffer_list,
     ), indices in grouped_tensors.values():
-        device_params: list[Tensor] = cast(list[Tensor], device_params_)
-        device_grads: list[Tensor] = cast(list[Tensor], device_grads_)
+        device_params: list[torch.Tensor] = device_params_
+        device_grads: list[torch.Tensor] = device_grads_
 
         if maximize:
             device_grads = torch._foreach_neg(device_grads)  # type: ignore[assignment]
@@ -76,9 +76,4 @@ def _sgd_torch(
             else:
                 device_grads = bufs
 
-        # handle internal item() call if lr is a tensor
-        if isinstance(lr, torch.Tensor) and torch.compiler.is_compiling():
-            grads_x_lr = torch._foreach_mul(device_grads, -lr)
-            torch._foreach_add_(device_params, grads_x_lr)
-        else:
-            torch._foreach_add_(device_params, device_grads, alpha=-lr)
+        torch._foreach_add_(device_params, device_grads, alpha=-lr)

--- a/xma/optimizers/sgd/torch_implementation.py
+++ b/xma/optimizers/sgd/torch_implementation.py
@@ -5,29 +5,29 @@
 from __future__ import annotations
 
 import torch
+from torch.optim.optimizer import Optimizer
 
 
 def _sgd_torch(
     params: list[torch.Tensor],
     grads: list[torch.Tensor],
-    momentum_buffer_list: list[torch.Tensor],
+    momentum_buffer_list: list[torch.Tensor | None],
     lr: float,
     weight_decay: float,
     momentum: float,
     dampening: float,
     nesterov: bool,
     maximize: bool,
+    step: int,
 ) -> None:
     grouped_tensors = Optimizer._group_tensors_by_device_and_dtype(
         [params, grads, momentum_buffer_list],  # type: ignore[list-item]
         with_indices=True,
     )
 
-    for (
-        device_params_,
-        device_grads_,
-        device_momentum_buffer_list,
-    ), indices in grouped_tensors.values():
+    is_first_step = step == 1
+
+    for (device_params_, device_grads_, device_momentum_buffer_list), indices in grouped_tensors.values():
         device_params: list[torch.Tensor] = device_params_
         device_grads: list[torch.Tensor] = device_grads_
 
@@ -44,36 +44,12 @@ def _sgd_torch(
                 )
 
         if momentum != 0:
-            bufs: list[Tensor] = []
-
-            all_states_with_momentum_buffer = True
-            for i in range(len(device_momentum_buffer_list)):
-                if device_momentum_buffer_list[i] is None:
-                    all_states_with_momentum_buffer = False
-                    break
-                else:
-                    bufs.append(cast(Tensor, device_momentum_buffer_list[i]))
-
-            if all_states_with_momentum_buffer:
-                torch._foreach_mul_(bufs, momentum)
-                torch._foreach_add_(bufs, device_grads, alpha=1 - dampening)
-            else:
-                bufs = []
-
-                for i in range(len(device_momentum_buffer_list)):
-                    if device_momentum_buffer_list[i] is None:
-                        buf = device_momentum_buffer_list[i] = momentum_buffer_list[indices[i]] = (
-                            device_grads[i].detach().clone()
-                        )
-                    else:
-                        buf = cast(Tensor, device_momentum_buffer_list[i])
-                        buf.mul_(momentum).add_(device_grads[i], alpha=1 - dampening)
-
-                    bufs.append(buf)
+            torch._foreach_mul_(device_momentum_buffer_list, momentum)
+            torch._foreach_add_(device_momentum_buffer_list, device_grads, alpha=1 if is_first_step else 1 - dampening)
 
             if nesterov:
-                torch._foreach_add_(device_grads, bufs, alpha=momentum)
+                torch._foreach_add_(device_grads, device_momentum_buffer_list, alpha=momentum)
             else:
-                device_grads = bufs
+                device_grads = device_momentum_buffer_list
 
         torch._foreach_add_(device_params, device_grads, alpha=-lr)

--- a/xma/optimizers/sgd/triton_implementation.py
+++ b/xma/optimizers/sgd/triton_implementation.py
@@ -9,11 +9,6 @@ from torch.distributed.tensor import DTensor
 
 from ...custom_op import xma_op
 from ...math import ceil_divide, get_powers_of_2
-from ...utils import is_triton_available
-
-
-if is_triton_available():
-    from .triton_implementation import _single_tensor_sgd_triton
 
 
 def _get_autotune_configs() -> list[triton.Config]:

--- a/xma/optimizers/sgd/triton_implementation.py
+++ b/xma/optimizers/sgd/triton_implementation.py
@@ -5,9 +5,16 @@
 import torch
 import triton
 import triton.language as tl
+from torch.distributed.tensor import DTensor
 
+from ...accelerator import Accelerator, KernelBackend
 from ...custom_op import xma_op
 from ...math import ceil_divide, get_powers_of_2
+from ...utils import is_triton_available
+
+
+if is_triton_available():
+    from .triton_implementation import _single_tensor_sgd_triton
 
 
 def _get_autotune_configs() -> list[triton.Config]:
@@ -168,4 +175,68 @@ def _single_tensor_sgd_triton(
             dampening=None if dampening == 0 else dampening,
             NESTEROV=nesterov,
             IS_FIRST_STEP=is_first_step,
+        )
+
+
+def _sgd_triton(
+    params: list[torch.Tensor],
+    grads: list[torch.Tensor],
+    momentum_buffer_list: list[torch.Tensor],
+    lr: float,
+    weight_decay: float,
+    momentum: float,
+    dampening: float,
+    nesterov: bool,
+    maximize: bool,
+) -> None:
+    if len(params) == 0:
+        return
+
+    is_first_step = False
+    if momentum == 0:
+        assert len(momentum_buffer_list) == 0
+        momentum_buffer_list = [None] * len(params)
+    elif momentum_buffer_list[0] is None:
+        assert all([m is None for m in momentum_buffer_list])
+        is_first_step = True
+
+        for i, p in enumerate(params):
+            momentum_buffer_list[i] = torch.empty_like(p, dtype=torch.float32)
+
+    is_dtensor = isinstance(params[0], DTensor)
+
+    if is_dtensor:
+        for W, dW, M in zip(params, grads, momentum_buffer_list):
+            assert isinstance(dW, DTensor)
+            assert W.placements == dW.placements
+
+            if M is not None:
+                assert isinstance(M, DTensor)
+                assert W.placements == M.placements
+
+    for W, dW, M in zip(params, grads, momentum_buffer_list):
+        assert W.is_contiguous()
+        dW = dW.contiguous()
+
+        if M is not None:
+            assert M.is_contiguous()
+
+        if is_dtensor:
+            W = W.to_local()
+            dW = dW.to_local()
+
+            if M is not None:
+                M = M.to_local()
+
+        _single_tensor_sgd_triton(
+            W=W,
+            dW=dW,
+            M=M,
+            lr=lr,
+            weight_decay=weight_decay,
+            momentum=momentum,
+            dampening=dampening,
+            nesterov=nesterov,
+            maximize=maximize,
+            is_first_step=is_first_step,
         )

--- a/xma/optimizers/sgd/triton_implementation.py
+++ b/xma/optimizers/sgd/triton_implementation.py
@@ -187,20 +187,10 @@ def _sgd_triton(
     dampening: float,
     nesterov: bool,
     maximize: bool,
+    step: int,
 ) -> None:
     if len(params) == 0:
         return
-
-    is_first_step = False
-    if momentum == 0:
-        assert len(momentum_buffer_list) == 0
-        momentum_buffer_list = [None] * len(params)
-    elif momentum_buffer_list[0] is None:
-        assert all([m is None for m in momentum_buffer_list])
-        is_first_step = True
-
-        for i, p in enumerate(params):
-            momentum_buffer_list[i] = torch.empty_like(p, dtype=torch.float32)
 
     is_dtensor = isinstance(params[0], DTensor)
 
@@ -237,5 +227,5 @@ def _sgd_triton(
             dampening=dampening,
             nesterov=nesterov,
             maximize=maximize,
-            is_first_step=is_first_step,
+            is_first_step=step == 1,
         )

--- a/xma/optimizers/sgd/triton_implementation.py
+++ b/xma/optimizers/sgd/triton_implementation.py
@@ -7,7 +7,6 @@ import triton
 import triton.language as tl
 from torch.distributed.tensor import DTensor
 
-from ...accelerator import Accelerator, KernelBackend
 from ...custom_op import xma_op
 from ...math import ceil_divide, get_powers_of_2
 from ...utils import is_triton_available


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added parameter-group–driven SGD with per-group step tracking and momentum-buffer handling.
  * Updated SGD execution to use kernel-backend selection (PyTorch/Triton) and changed `step` to take only the backend selector and return no loss.
* **Documentation**
  * Added/linked Sphinx API documentation for SGD parameter groups.
* **Chores**
  * Updated package exports: top-level `set_seed` is now available; removed top-level `SGD`/`sgd` re-exports; re-exported `SGDParamsGroup` via `xma.optimizers`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->