### PR TITLE
[CLEANUP] avoid global imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ port=8001
 num_accelerators ?= $(shell uv run python -c "import torch; n=torch.cuda.device_count(); print(n if n > 0 else 1)" 2>/dev/null || echo 1)
 
 test:
-	uv run --extra dev --extra $(accelerator) pytest -n $(num_accelerators) tests
+	NUM_ACCELERATORS=$(num_accelerators) uv run --extra dev --extra $(accelerator) pytest -n $(num_accelerators) tests
 
 test-cpu:
 	uv run --extra dev --extra cpu pytest tests
@@ -16,7 +16,7 @@ test-mps:
 	uv run --extra dev --extra mps pytest tests
 
 test-cuda:
-	uv run --extra dev --extra cuda pytest -n $(num_accelerators) tests
+	NUM_ACCELERATORS=$(num_accelerators) uv run --extra dev --extra cuda pytest -n $(num_accelerators) tests
 
 # torch-xla and jax share a single TPU runtime per host, so unlike CUDA they aren't split across xdist workers
 # here - multiple workers would race each other for the TPU chip instead of getting a device each.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,20 +4,14 @@
 
 import os
 
-from xma import Accelerator, is_torch_available
 
+# torch.cuda reads CUDA_VISIBLE_DEVICES once, on its first CUDA call, and ignores any later
+# writes to it in the same process. conftest.py is imported before any test module, and `xma`
+# touches torch.cuda at import time, so this must stay import-free (os.environ only) and run
+# here rather than in a pytest_configure hook, which would already run too late.
+_worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+_num_accelerators = int(os.environ.get("NUM_ACCELERATORS", "0"))
 
-def pytest_configure(config) -> None:
-    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
-    if worker_id is None:
-        return
-
-    if not is_torch_available() or Accelerator.get_accelerator() not in [Accelerator.cuda, Accelerator.rocm]:
-        return
-
-    num_accelerators = Accelerator.device_count()
-    if num_accelerators == 0:
-        return
-
-    gpu_id = int(worker_id.replace("gw", "")) % num_accelerators
+if _worker_id is not None and _num_accelerators > 0:
+    gpu_id = int(_worker_id.replace("gw", "")) % _num_accelerators
     os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)

--- a/tests/functional/bmm_test.py
+++ b/tests/functional/bmm_test.py
@@ -9,7 +9,8 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from xma import KernelBackend, bmm, set_seed
+from xma import KernelBackend, set_seed
+from xma.functional import bmm
 
 from ..utils import assert_equal_tensors, get_2d_tensor_sizes, skip_if_incompatible_kernel_backend
 

--- a/tests/functional/continuous_count_test.py
+++ b/tests/functional/continuous_count_test.py
@@ -9,7 +9,8 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from xma import KernelBackend, continuous_count, set_seed
+from xma import KernelBackend, set_seed
+from xma.functional import continuous_count
 
 from ..utils import assert_equal_tensors, get_1d_tensor_sizes, skip_if_incompatible_kernel_backend
 

--- a/tests/functional/cross_entropy_test.py
+++ b/tests/functional/cross_entropy_test.py
@@ -9,7 +9,8 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from xma import KernelBackend, cross_entropy, set_seed
+from xma import KernelBackend, set_seed
+from xma.functional import cross_entropy
 
 from ..utils import (
     assert_equal_tensors,

--- a/tests/functional/fused_linear_cross_entropy_test.py
+++ b/tests/functional/fused_linear_cross_entropy_test.py
@@ -10,7 +10,8 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from xma import KernelBackend, fused_linear_cross_entropy, set_seed
+from xma import KernelBackend, set_seed
+from xma.functional import fused_linear_cross_entropy
 
 from ..utils import (
     assert_equal_tensors,

--- a/tests/functional/fused_residual_add_rmsnorm_test.py
+++ b/tests/functional/fused_residual_add_rmsnorm_test.py
@@ -9,7 +9,8 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from xma import KernelBackend, fused_residual_add_rmsnorm, set_seed
+from xma import KernelBackend, set_seed
+from xma.functional import fused_residual_add_rmsnorm
 
 from ..utils import (
     assert_equal_tensors,

--- a/tests/functional/p_norm_test.py
+++ b/tests/functional/p_norm_test.py
@@ -9,7 +9,8 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from xma import KernelBackend, p_norm, set_seed
+from xma import KernelBackend, set_seed
+from xma.functional import p_norm
 
 from ..utils import assert_equal_tensors, get_random_duplicated_tensors, skip_if_incompatible_kernel_backend
 from .fused_residual_add_rmsnorm_test import _get_sizes

--- a/tests/functional/pack_sequence_test.py
+++ b/tests/functional/pack_sequence_test.py
@@ -9,7 +9,8 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from xma import KernelBackend, pack_sequence, unpack_sequence
+from xma import KernelBackend
+from xma.functional import pack_sequence, unpack_sequence
 
 from ..utils import assert_equal_tensors, get_random_duplicated_tensors, skip_if_incompatible_kernel_backend
 

--- a/tests/functional/rmsnorm_test.py
+++ b/tests/functional/rmsnorm_test.py
@@ -14,8 +14,10 @@ torch = pytest.importorskip("torch")
 import torch._inductor.config as config
 import torch.nn as nn
 
-from xma import KernelBackend, enable_counters, enable_kernels, get_counter_value, reset_counters, rmsnorm, set_seed
-from xma.inductor import _CallablePatternMatcherPass
+from xma import KernelBackend, set_seed
+from xma.counters import enable_counters, get_counter_value, reset_counters
+from xma.functional import rmsnorm
+from xma.inductor import _CallablePatternMatcherPass, enable_kernels
 
 from ..utils import assert_equal_tensors, get_random_duplicated_tensors, skip_if_incompatible_kernel_backend
 from .fused_residual_add_rmsnorm_test import _get_sizes

--- a/tests/functional/softmax_test.py
+++ b/tests/functional/softmax_test.py
@@ -9,7 +9,8 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from xma import KernelBackend, set_seed, softmax
+from xma import KernelBackend, set_seed
+from xma.functional import softmax
 
 from ..utils import assert_equal_tensors, get_random_duplicated_tensors, skip_if_incompatible_kernel_backend
 from .rmsnorm_test import _get_sizes

--- a/tests/functional/swiglu_packed_test.py
+++ b/tests/functional/swiglu_packed_test.py
@@ -9,7 +9,9 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from xma import KernelBackend, ceil_divide, swiglu_packed
+from xma import KernelBackend
+from xma.functional import swiglu_packed
+from xma.math import ceil_divide
 
 from ..utils import assert_equal_tensors, get_random_duplicated_tensors, skip_if_incompatible_kernel_backend
 from .swiglu_test import _generate_args

--- a/tests/functional/swiglu_test.py
+++ b/tests/functional/swiglu_test.py
@@ -10,7 +10,8 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from xma import KernelBackend, swiglu
+from xma import KernelBackend
+from xma.functional import swiglu
 
 from ..utils import (
     assert_equal_tensors,

--- a/tests/layers/gru_test.py
+++ b/tests/layers/gru_test.py
@@ -9,7 +9,8 @@ torch = pytest.importorskip("torch")
 
 import torch.nn as nn
 
-from xma import GRU, KernelBackend, set_seed
+from xma import KernelBackend, set_seed
+from xma.layers import GRU
 
 from ..utils import (
     assert_equal_tensors,

--- a/tests/layers/linear_attention_test.py
+++ b/tests/layers/linear_attention_test.py
@@ -9,7 +9,8 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from xma import KernelBackend, LinearAttention, set_seed
+from xma import KernelBackend, set_seed
+from xma.layers import LinearAttention
 
 from ..utils import assert_equal_tensors, skip_if_incompatible_kernel_backend
 from .rnn_test import _get_packed_tensor_inputs

--- a/tests/layers/m2rnn_test.py
+++ b/tests/layers/m2rnn_test.py
@@ -11,7 +11,8 @@ torch = pytest.importorskip("torch")
 
 import torch.nn as nn
 
-from xma import M2RNN, KernelBackend, set_seed
+from xma import KernelBackend, set_seed
+from xma.layers import M2RNN
 
 from ..utils import (
     assert_equal_tensors,

--- a/tests/layers/moe_test.py
+++ b/tests/layers/moe_test.py
@@ -9,7 +9,8 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from xma import KernelBackend, MoE, set_seed
+from xma import KernelBackend, set_seed
+from xma.layers import MoE
 
 from ..utils import (
     assert_equal_tensors,

--- a/tests/layers/rnn_test.py
+++ b/tests/layers/rnn_test.py
@@ -9,7 +9,8 @@ torch = pytest.importorskip("torch")
 
 import torch.nn as nn
 
-from xma import RNN, KernelBackend, set_seed
+from xma import KernelBackend, set_seed
+from xma.layers import RNN
 
 from ..utils import (
     assert_equal_tensors,

--- a/tests/layers_jax/linear_attention_jax_test.py
+++ b/tests/layers_jax/linear_attention_jax_test.py
@@ -14,7 +14,8 @@ jax = pytest.importorskip("jax")
 import haliax
 import jax.numpy as jnp
 
-from xma import KernelBackend, LinearAttentionJAX, linear_attention_jax
+from xma import KernelBackend
+from xma.layers_jax import LinearAttentionJAX, linear_attention_jax
 
 
 _ATTENTION_MULTIPLIER = 0.3

--- a/xma/__init__.py
+++ b/xma/__init__.py
@@ -3,33 +3,4 @@
 # **************************************************
 
 from .accelerator import Accelerator, KernelBackend
-from .counters import enable_counters, get_counter_value, reset_counters
-from .math import ceil_divide, divide_if_divisible, get_powers_of_2
 from .utils import get_ptx_from_triton_kernel, is_haliax_available, is_jax_available, is_torch_available, set_seed
-
-
-if is_jax_available():
-    from .layers_jax import linear_attention_jax
-
-    if is_haliax_available():
-        from .layers_jax import LinearAttentionJAX
-
-
-if is_torch_available():
-    from .autotuner import AutotuneConfig, autotune, get_cartesian_product_autotune_configs
-    from .functional import (
-        bmm,
-        continuous_count,
-        cross_entropy,
-        fused_linear_cross_entropy,
-        fused_residual_add_rmsnorm,
-        p_norm,
-        pack_sequence,
-        rmsnorm,
-        softmax,
-        swiglu,
-        swiglu_packed,
-        unpack_sequence,
-    )
-    from .inductor import enable_kernels
-    from .layers import GRU, M2RNN, RNN, LinearAttention, MoE, gru, linear_attention, m2rnn, rnn


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Functional operations and neural-network layers are now accessed through their dedicated modules rather than the package’s top-level namespace.
  - Utility, accelerator, and backend helpers remain available from the main package entry point.

- **Bug Fixes**
  - Parallel GPU test runs now assign devices more reliably based on the configured accelerator count.

- **Tests**
  - Updated test coverage to use the reorganized module paths across functional operations and layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->